### PR TITLE
Fix protocol specification

### DIFF
--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -104,7 +104,7 @@ snappy-compression = %x2
 
 version            = %x1
 
-device-number      = 2OCTET              ; uint16, network byte order
+device-number      = 4OCTET              ; uint32, network byte order
 created-ms         = 8OCTET              ; uint64, network byte order
 sequence-number    = 8OCTET              ; uint64, network byte order
 ```


### PR DESCRIPTION
According to the [implementation](https://github.com/skaes/logjam-tools/blob/master/src/logjam-util.h#L53) the `device-number` field is a `uint32` and not `uint16` as stated in the specification.
