### PR TITLE
Building modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ use the `--prefix` argument like so:
 ./bin/install-libs --prefix=/opt/logjam
 ```
 
+If you are using Homebrew as your package manager on Mac OS it is recommended to
+install the libraries with `--without-documentation` to prevent issues arising
+from trying to validate XML files that can seemingly only be validated when
+`docbook-xsl-nons` is installed.
+
 Or install them manually:
 * Download and install zmq 4.1.4 from http://zeromq.org/intro:get-the-software
 * Dowmload and install czmq 3.0.2 from http://czmq.zeromq.org/page:get-the-software

--- a/bin/install-libs
+++ b/bin/install-libs
@@ -5,6 +5,7 @@ build_dir="builds/repos"
 forced=0
 prefix=/usr/local
 cached=0
+documentation=1
 
 test -z "$LSUDO" && LSUDO="sudo"
 test "$(whoami)" = "root" && LSUDO=""
@@ -23,8 +24,10 @@ while (( $# > 0 )); do
             prefix="$2"; shift 2;;
         --prefix=*)
             prefix="${1#--prefix=}"; shift;;
+        --without-documentation)
+            documentation=0; shift;;
         --*)
-            echo "$(basename $0) [--force] [--cached] [--build-dir dir] [--prefix dir] [install|uninstall]"; exit 0;;
+            echo "$(basename $0) [--force] [--cached] [--without-documentation] [--build-dir dir] [--prefix dir] [install|uninstall]"; exit 0;;
         *) break ;;
     esac
 done
@@ -176,7 +179,11 @@ function handle_zeromq()
         git checkout $expected_revision
     fi
     [ $forced == "1" ] && git clean -qfdx
-    test -f config.status || (sh autogen.sh && ./configure --prefix=$prefix --without-documentation)
+    additional_configure_flags=""
+    if [ "$documentation" == "0" ]; then
+      additional_configure_flags="--without-documentation"
+    fi
+    test -f config.status || (sh autogen.sh && ./configure --prefix=$prefix $additional_configure_flags)
     make -j4
     $LSUDO make $cmd
     $LSUDO $ldconfig
@@ -196,11 +203,12 @@ function handle_czmq()
         git checkout $expected_revision
     fi
     [ $forced == "1" ] && git clean -qfdx
-    (
-      gsed -i 's/czmq_build_doc="yes"/czmq_build_doc="no"/g' configure.ac &&
-      gsed -i 's/czmq_install_man="yes"/czmq_install_man="no"/g' configure.ac &&
-      sh autogen.sh &&
-        ./configure --prefix=$prefix
+    test -f config.status || (
+      if [ "$documentation" == "0" ]; then
+        gsed -i 's/czmq_build_doc="yes"/czmq_build_doc="no"/g' configure.ac &&
+        gsed -i 's/czmq_install_man="yes"/czmq_install_man="no"/g' configure.ac
+      fi
+      sh autogen.sh && ./configure --prefix=$prefix
     )
     make -j4
     $LSUDO make $cmd

--- a/bin/install-libs
+++ b/bin/install-libs
@@ -152,10 +152,10 @@ function handle_sodium()
     v=1.0.16
     d=libsodium-$v
     f=${d}.tar.gz
-    test -f $f || wget -nv https://github.com/jedisct1/libsodium/releases/download/$v/$f
-    test -d $d || tar xzvf $f
+    test -f $f && [ $forced != "1" ] || wget -nv https://github.com/jedisct1/libsodium/releases/download/$v/$f
+    test -d $d && [ $forced != "1" ]|| tar xzvf $f
     cd $d
-    [ $forced == "1" ] && rm -f config.status && git clean -fqdx
+    [ $forced == "1" ] && rm -f config.status
     test -f config.status || ./configure --prefix=$prefix
     make -j4
     $LSUDO make $cmd
@@ -176,7 +176,7 @@ function handle_zeromq()
         git checkout $expected_revision
     fi
     [ $forced == "1" ] && git clean -qfdx
-    test -f config.status || (sh autogen.sh && ./configure --prefix=$prefix)
+    test -f config.status || (sh autogen.sh && ./configure --prefix=$prefix --without-documentation)
     make -j4
     $LSUDO make $cmd
     $LSUDO $ldconfig
@@ -196,7 +196,12 @@ function handle_czmq()
         git checkout $expected_revision
     fi
     [ $forced == "1" ] && git clean -qfdx
-    test -f config.status || (sh autogen.sh && ./configure --prefix=$prefix)
+    (
+      gsed -i 's/czmq_build_doc="yes"/czmq_build_doc="no"/g' configure.ac &&
+      gsed -i 's/czmq_install_man="yes"/czmq_install_man="no"/g' configure.ac &&
+      sh autogen.sh &&
+        ./configure --prefix=$prefix
+    )
     make -j4
     $LSUDO make $cmd
     $LSUDO $ldconfig

--- a/bin/install-libs
+++ b/bin/install-libs
@@ -115,7 +115,7 @@ function handle_mongoc()
     [ $forced == "1" ] && git clean -qfdx && rm -rf cmake-build
     mkdir -p cmake-build
     cd cmake-build
-    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_INSTALL_LIBDIR=$prefix/lib ..
+    cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_INSTALL_LIBDIR=$prefix/lib -DCMAKE_MACOSX_RPATH=ON ..
     if [ "$cmd" == "install" ]; then
         make
         $LSUDO make install

--- a/bin/install-libs
+++ b/bin/install-libs
@@ -203,12 +203,13 @@ function handle_czmq()
         git checkout $expected_revision
     fi
     [ $forced == "1" ] && git clean -qfdx
+    if [ "$documentation" == "0" ]; then
+      sed -ie 's/czmq_build_doc="yes"/czmq_build_doc="no"/g' configure.ac &&
+        sed -ie 's/czmq_install_man="yes"/czmq_install_man="no"/g' configure.ac
+    fi
     test -f config.status || (
-      if [ "$documentation" == "0" ]; then
-        gsed -i 's/czmq_build_doc="yes"/czmq_build_doc="no"/g' configure.ac &&
-        gsed -i 's/czmq_install_man="yes"/czmq_install_man="no"/g' configure.ac
-      fi
-      sh autogen.sh && ./configure --prefix=$prefix
+      sh autogen.sh &&
+      ./configure --prefix=$prefix
     )
     make -j4
     $LSUDO make $cmd

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,8 @@ AS_IF([test "x$prefix" != "x"],
       [ PKG_CONFIG_PATH="$prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
         export PKG_CONFIG_PATH
         AC_SUBST([PKG_CONFIG_PATH], [$PKG_CONFIG_PATH])
-        AC_SUBST([OPTDIR_LDFLAGS], ["-Wl,-rpath -Wl,$libdir"])
+        AC_SUBST([OPTDIR_LDFLAGS], ["-Xlinker -rpath -Xlinker $libdir"])
+        dnl AC_SUBST([OPTDIR_LDFLAGS], ["-Wl,-rpath,$libdir"])
       ])
 
 AS_IF([test "x$with_opt_dir" == "x"],
@@ -75,7 +76,7 @@ AS_IF([test "x$with_opt_dir" == "x"],
 
 dnl AS_IF([test "x$DEPS_LIBS" != "x"],
 dnl       [ echo $DEPS_LIBS
-dnl         val=`echo $DEPS_LIBS | sed 's|-L\(/[[^ ]*]\)| -L\1 -Wl,-rpath -Wl,\1|g'`
+dnl         val=`echo $DEPS_LIBS | sed 's|-L\(/[[^ ]*]\)| -L\1 -Wl,-rpath,\1|g'`
 dnl         echo $val
 dnl         AC_SUBST([DEPS_LIBS], $val)
 dnl       ])

--- a/configure.ac
+++ b/configure.ac
@@ -53,8 +53,7 @@ AS_IF([test "x$prefix" != "x"],
       [ PKG_CONFIG_PATH="$prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
         export PKG_CONFIG_PATH
         AC_SUBST([PKG_CONFIG_PATH], [$PKG_CONFIG_PATH])
-        AC_SUBST([OPTDIR_LDFLAGS], ["-Xlinker -rpath -Xlinker $libdir"])
-        dnl AC_SUBST([OPTDIR_LDFLAGS], ["-Wl,-rpath,$libdir"])
+        AC_SUBST([OPTDIR_LDFLAGS], ["-Wl,-rpath -Wl,$libdir"])
       ])
 
 AS_IF([test "x$with_opt_dir" == "x"],
@@ -76,7 +75,7 @@ AS_IF([test "x$with_opt_dir" == "x"],
 
 dnl AS_IF([test "x$DEPS_LIBS" != "x"],
 dnl       [ echo $DEPS_LIBS
-dnl         val=`echo $DEPS_LIBS | sed 's|-L\(/[[^ ]*]\)| -L\1 -Wl,-rpath,\1|g'`
+dnl         val=`echo $DEPS_LIBS | sed 's|-L\(/[[^ ]*]\)| -L\1 -Wl,-rpath -Wl,\1|g'`
 dnl         echo $val
 dnl         AC_SUBST([DEPS_LIBS], $val)
 dnl       ])

--- a/m4/ax_check_zlib.m4
+++ b/m4/ax_check_zlib.m4
@@ -123,7 +123,7 @@ then
     # If both library and header were found, action-if-found
     #
     m4_ifblank([$1],[
-                if test "${ZLIB_HOME}" != "/usr"; then
+                if test "${ZLIB_HOME}" != "/usr" && test -n "${ZLIB_HOME}"; then
                   CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
                   LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
                 fi


### PR DESCRIPTION
This does the following:

* Add a `--without-documentation` flag to `bin/install-libs` to support installing libraries when using Homebrew as a package manager (Homebrew doesn't install `docbook-xsl-nons` while macports does).
* Add `CMAKE_MACOSX_RPATH=ON` for mongo-c-driver building to convince cmake to set `@rpath` correctly for libbson.
  * This is fixed in upstream with version 1.13.1 of mongo-c-driver
* Fix zlib LDFLAGS setting where under certain circumstances autogen would define `LDFLAGS = /lib` which should be invalid on most systems and causes the linker to issue a warning.