### PR TITLE
Update logjam-dump to support writing the payload frame only instead of the full message

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.associations": {
+        "array": "c",
+        "iterator": "c",
+        "string": "c",
+        "string_view": "c",
+        "vector": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "files.associations": {
-        "array": "c",
-        "iterator": "c",
-        "string": "c",
-        "string_view": "c",
-        "vector": "c"
-    }
-}

--- a/src/logjam-dump.c
+++ b/src/logjam-dump.c
@@ -3,6 +3,7 @@
 #include <getopt.h>
 
 FILE* dump_file = NULL;
+zchunk_t *dump_decompress_buffer;
 static char *dump_file_name = "logjam-stream.dump";
 
 static size_t io_threads = 1;
@@ -81,7 +82,7 @@ static int read_zmq_message_and_dump(zloop_t *loop, zsock_t *socket, void *callb
     // dump message to file annd free memory
     if (!is_heartbeat) {
         if (payload_only) {
-            dump_message_payload(msg, dump_file);
+            dump_message_payload(msg, dump_file, dump_decompress_buffer);
         } else {
             zmsg_savex(msg, dump_file);
         }
@@ -198,6 +199,7 @@ int main(int argc, char * const *argv)
 
     process_arguments(argc, argv);
 
+    dump_decompress_buffer = zchunk_new(NULL, INITIAL_DECOMPRESSION_BUFFER_SIZE);
     // open dump file
     dump_file = fopen(dump_file_name, "w");
     if (!dump_file) {
@@ -205,6 +207,7 @@ int main(int argc, char * const *argv)
         exit(1);
     }
     if (verbose) printf("[I] dumping stream to %s\n", dump_file_name);
+
 
     // set global config
     zsys_init();
@@ -217,6 +220,7 @@ int main(int argc, char * const *argv)
     // create socket to receive messages on
     zsock_t *receiver = zsock_new(ZMQ_SUB);
     assert_x(receiver != NULL, "zmq socket creation failed", __FILE__, __LINE__);
+    
 
     // connect socket
     char *spec = zlist_first(connection_specs);
@@ -285,6 +289,7 @@ int main(int argc, char * const *argv)
 
     device_tracker_destroy(&tracker);
     fclose(dump_file);
+    zchunk_destroy(&dump_decompress_buffer);
     zloop_destroy(&loop);
     assert(loop == NULL);
     zsock_destroy(&receiver);

--- a/src/logjam-dump.c
+++ b/src/logjam-dump.c
@@ -81,7 +81,7 @@ static int read_zmq_message_and_dump(zloop_t *loop, zsock_t *socket, void *callb
     // dump message to file annd free memory
     if (!is_heartbeat) {
         if (payload_only) {
-            zmsg_savex_payload(msg, dump_file);
+            dump_message_payload(msg, dump_file);
         } else {
             zmsg_savex(msg, dump_file);
         }

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -620,7 +620,7 @@ zmsg_savex (zmsg_t *self, FILE *file)
 }
 
 // dump the payload frame of the message only
-int dump_message_payload (zmsg_t *self, FILE *file) 
+int dump_message_payload (zmsg_t *self, FILE *file, zchunk_t *buffer) 
 {
     assert (self);
     assert (zmsg_is (self));
@@ -636,9 +636,7 @@ int dump_message_payload (zmsg_t *self, FILE *file)
     if (compression_method) {
         char *body;
         size_t body_len;
-        zchunk_t *buffer = zchunk_new(NULL, INITIAL_DECOMPRESSION_BUFFER_SIZE);
         int rc = decompress_frame(frame, compression_method, buffer, &body, &body_len);
-        zchunk_destroy(&buffer);
         if (rc == 0) {
             fprintf(stderr, "[E] decompressor: could not decompress payload from\n");
             return -1;

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -589,6 +589,15 @@ void my_zmq_msg_fprint(zmq_msg_t* msg, size_t n, const char* prefix, FILE* file 
     }
 }
 
+int zmsg_savex_frame(zframe_t *frame, FILE *file) {
+    size_t frame_size = zframe_size (frame);
+    if (fwrite (&frame_size, sizeof (frame_size), 1, file) != 1)
+        return -1;
+    if (fwrite (zframe_data (frame), frame_size, 1, file) != 1)
+        return -1;
+    return 0;
+}
+
 //  --------------------------------------------------------------------------
 //  Save message to an open file, return 0 if OK, else -1. The message is
 //  saved as a series of frames, each with length and data. Note that the
@@ -628,15 +637,6 @@ int zmsg_savex_payload(zmsg_t *self, FILE *file) {
     frame = zmsg_next (self); //payload
 
     return zmsg_savex_frame(frame, file);
-}
-
-int zmsg_savex_frame(zframe_t *frame, FILE *file) {
-    size_t frame_size = zframe_size (frame);
-    if (fwrite (&frame_size, sizeof (frame_size), 1, file) != 1)
-        return -1;
-    if (fwrite (zframe_data (frame), frame_size, 1, file) != 1)
-        return -1;
-    return 0;
 }
 
 //  --------------------------------------------------------------------------

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -609,13 +609,33 @@ zmsg_savex (zmsg_t *self, FILE *file)
 
     zframe_t *frame = zmsg_first (self);
     while (frame) {
-        size_t frame_size = zframe_size (frame);
-        if (fwrite (&frame_size, sizeof (frame_size), 1, file) != 1)
+        if (zmsg_savex_frame(frame, file) != 0) {
             return -1;
-        if (fwrite (zframe_data (frame), frame_size, 1, file) != 1)
-            return -1;
+        } 
         frame = zmsg_next (self);
     }
+    return 0;
+}
+
+// Save the payload frame of the message only
+int zmsg_savex_payload(zmsg_t *self, FILE *file) {
+    assert (self);
+    assert (zmsg_is (self));
+    assert (file);
+
+    zframe_t *frame = zmsg_first (self); // topic
+    frame = zmsg_next (self); // routing key
+    frame = zmsg_next (self); //payload
+
+    return zmsg_savex_frame(frame, file);
+}
+
+int zmsg_savex_frame(zframe_t *frame, FILE *file) {
+    size_t frame_size = zframe_size (frame);
+    if (fwrite (&frame_size, sizeof (frame_size), 1, file) != 1)
+        return -1;
+    if (fwrite (zframe_data (frame), frame_size, 1, file) != 1)
+        return -1;
     return 0;
 }
 

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -638,11 +638,11 @@ int zmsg_savex_payload (zmsg_t *self, FILE *file)
         size_t body_len;
         zchunk_t *buffer = zchunk_new(NULL, INITIAL_DECOMPRESSION_BUFFER_SIZE);
         int rc = decompress_frame(frame, compression_method, buffer, &body, &body_len);
+        zchunk_destroy(&buffer);
         if (rc == 0) {
             fprintf(stderr, "[E] decompressor: could not decompress payload from\n");
             return -1;
         }
-        zchunk_destroy(&buffer);
         if (fputs (body, file) != 1)
             return -1;
     } else {

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -619,8 +619,8 @@ zmsg_savex (zmsg_t *self, FILE *file)
     return 0;
 }
 
-// Save the payload frame of the message only
-int zmsg_savex_payload (zmsg_t *self, FILE *file) 
+// dump the payload frame of the message only
+int dump_message_payload (zmsg_t *self, FILE *file) 
 {
     assert (self);
     assert (zmsg_is (self));

--- a/src/logjam-util.h
+++ b/src/logjam-util.h
@@ -203,7 +203,7 @@ static inline zmsg_t* zmsg_recv_with_retry(zsock_t *socket)
 }
 
 extern int zmsg_savex (zmsg_t *self, FILE *file);
-extern int dump_message_payload(zmsg_t *self, FILE *file);
+extern int dump_message_payload(zmsg_t *self, FILE *file, zchunk_t *buffer);
 extern zmsg_t* zmsg_loadx (zmsg_t *self, FILE *file);
 
 extern zhash_t* zlist_to_hash(zlist_t *list);

--- a/src/logjam-util.h
+++ b/src/logjam-util.h
@@ -203,6 +203,7 @@ static inline zmsg_t* zmsg_recv_with_retry(zsock_t *socket)
 }
 
 extern int zmsg_savex (zmsg_t *self, FILE *file);
+extern int zmsg_savex_payload(zmsg_t *self, FILE *file);
 extern zmsg_t* zmsg_loadx (zmsg_t *self, FILE *file);
 
 extern zhash_t* zlist_to_hash(zlist_t *list);

--- a/src/logjam-util.h
+++ b/src/logjam-util.h
@@ -203,7 +203,7 @@ static inline zmsg_t* zmsg_recv_with_retry(zsock_t *socket)
 }
 
 extern int zmsg_savex (zmsg_t *self, FILE *file);
-extern int zmsg_savex_payload(zmsg_t *self, FILE *file);
+extern int dump_message_payload(zmsg_t *self, FILE *file);
 extern zmsg_t* zmsg_loadx (zmsg_t *self, FILE *file);
 
 extern zhash_t* zlist_to_hash(zlist_t *list);


### PR DESCRIPTION
* Added option '-l/--payload' to logjam-dump

* When option '-l' is used only dump the payload frame of the message instead
of the full message