### PR TITLE
add missing observations for application level metrics

### DIFF
--- a/go/prometheusexporter/collector/collector.go
+++ b/go/prometheusexporter/collector/collector.go
@@ -741,14 +741,20 @@ func (c *Collector) recordLogMetrics(m *metric) {
 	switch metric {
 	case "http":
 		p["type"] = c.requestType(action)
-		c.actionMetrics.httpRequestSummaryVec.With(p).Observe(m.value)
-		delete(p, "code")
-		delete(p, "method")
-		p["level"] = m.maxLogLevel
-		c.actionMetrics.httpRequestsTotalVec.With(p).Add(1)
-		delete(p, "level")
-		c.actionMetrics.transactionsTotalVec.With(p).Add(1)
 		q := removeAction(p)
+		c.actionMetrics.httpRequestSummaryVec.With(p).Observe(m.value)
+		c.applicationMetrics.httpRequestSummaryVec.With(q).Observe(m.value)
+		delete(p, "code")
+		delete(q, "code")
+		delete(p, "method")
+		delete(q, "method")
+		p["level"] = m.maxLogLevel
+		q["level"] = m.maxLogLevel
+		c.actionMetrics.httpRequestsTotalVec.With(p).Add(1)
+		c.applicationMetrics.httpRequestsTotalVec.With(q).Add(1)
+		delete(p, "level")
+		delete(q, "level")
+		c.actionMetrics.transactionsTotalVec.With(p).Add(1)
 		c.applicationMetrics.transactionsTotalVec.With(q).Add(1)
 		for k, v := range m.timeMetrics {
 			if vec := c.actionMetrics.requestMetricsSummaryMap[k]; vec != nil {

--- a/go/prometheusexporter/collector/collector_test.go
+++ b/go/prometheusexporter/collector/collector_test.go
@@ -1,9 +1,10 @@
 package collector
 
 import (
-	"github.com/skaes/logjam-tools/go/util"
 	"sync"
 	"testing"
+
+	"github.com/skaes/logjam-tools/go/util"
 )
 
 func TestExtractingMetricNames(t *testing.T) {
@@ -116,10 +117,10 @@ func TestDeletingLabels(t *testing.T) {
 	c.recordLogMetrics(metrics2)
 	c.recordLogMetrics(metrics3)
 	c.recordLogMetrics(metrics4)
-	if !c.removeAction("marks") {
+	if !c.copyWithoutActionLabel("marks") {
 		t.Errorf("could not remove action: %s", "marks")
 	}
-	if c.removeAction("schnippi") {
+	if c.copyWithoutActionLabel("schnippi") {
 		t.Errorf("could remove non existing action : %s", "schnippi")
 	}
 }


### PR DESCRIPTION
It turns out that we missed the individual observations for two metrics when we merged https://github.com/skaes/logjam-tools/pull/33. This PR adds them.

* logjam:application:http_response_time_summary_seconds
* logjam:application:http_requests_total