### PR TITLE
Align logjam spec

### DIFF
--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -29,7 +29,7 @@ information intended to specify that the following output is produced
 by the producer and "C:" is used to mark consumer output. ZeroMQ frame
 delimiters are left out in order to simplify the presentation.
 
-```
+```abnf
 consumer-stream = *(S: data-msg)
 ```
 
@@ -43,7 +43,7 @@ finally a frame containing meta information, such as protocol version,
 compression method used for the JSON body, when the messages was
 produced and a message sequence number.
 
-```
+```abnf
 data-msg = app-env topic json-body meta-info
 
 app-env      = application "-" environment

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -50,12 +50,12 @@ app-env      = application "-" environment
 application  = ALPHA *(ALPHA / "_" / "-")
 environment  = ALPHA *(ALPHA / "_")
 
-topic = logs *( "." ALPHA *ALPHA )         ; normal log messages
-topic /= javascript *( "." ALPHA *ALPHA )  ; javascript errors
-topic /= events *( "." ALPHA *ALPHA )      ; logjam event
-topic /= frontend.page                     ; frontend metric (page render)
-topic /= frontend.ajax                     ; frontend metric (ajax call)
-topic /= mobile                            ; mobile metric
+topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic /= frontend.page                                   ; frontend metric (page render)
+topic /= frontend.ajax                                   ; frontend metric (ajax call)
+topic /= mobile                                          ; mobile metric
 
 body = *OCTET                              ; JSON string, possibly compressed
 

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -57,9 +57,9 @@ app-env      = application "-" environment
 application  = ALPHA *(ALPHA / "_" / "-")
 environment  = ALPHA *(ALPHA / "_")
 
-topic = logs 1*( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
-topic /= javascript 1*( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
-topic /= events 1*( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
 topic /= frontend.page                                   ; frontend metric (page render)
 topic /= frontend.ajax                                   ; frontend metric (ajax call)
 topic /= mobile                                          ; mobile metric

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -57,9 +57,9 @@ app-env      = application "-" environment
 application  = ALPHA *(ALPHA / "_" / "-")
 environment  = ALPHA *(ALPHA / "_")
 
-topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
-topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
-topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic = logs 1*( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript 1*( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events 1*( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
 topic /= frontend.page                                   ; frontend metric (page render)
 topic /= frontend.ajax                                   ; frontend metric (ajax call)
 topic /= mobile                                          ; mobile metric

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -61,7 +61,7 @@ body = *OCTET                              ; JSON string, possibly compressed
 
 meta-info = tag compression-method version device-number created-ms sequence-number
 
-tag = %xCABD                               ; tag is used internally to detect programming errors
+tag = %xCA %xBD                          ; tag is used internally to detect programming errors
 
 compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression
 no-compression     = %d0

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -64,12 +64,12 @@ meta-info = tag compression-method version device-number created-ms sequence-num
 tag = %xCABD                               ; tag is used internally to detect programming errors
 
 compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression
-no-compression     = %x0
-zlib-compression   = %x1
-snappy-compression = %x2
-lz4-compression    = %x3
+no-compression     = %d0
+zlib-compression   = %d1
+snappy-compression = %d2
+lz4-compression    = %d3
 
-version            = %x1
+version            = %d1
 
 device-number      = 2OCTET                ; uint16, network byte order
 created-ms         = 8OCTET                ; uint64, network byte order

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -71,9 +71,9 @@ lz4-compression    = %d3
 
 version            = %d1
 
-device-number      = 2OCTET                ; uint16, network byte order
-created-ms         = 8OCTET                ; uint64, network byte order
-sequence-number    = 8OCTET                ; uint64, network byte order
+device-number      = 2(OCTET)              ; uint16, network byte order
+created-ms         = 8(OCTET)              ; uint64, network byte order
+sequence-number    = 8(OCTET)              ; uint64, network byte order
 ```
 
 Note: as of version 1, the format is identical to the format used in

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -78,7 +78,7 @@ lz4-compression    = %d3
 
 version            = %d1
 
-device-number      = 2(OCTET)              ; uint16, network byte order
+device-number      = 4(OCTET)              ; uint32, network byte order
 created-ms         = 8(OCTET)              ; uint64, network byte order
 sequence-number    = 8(OCTET)              ; uint64, network byte order
 ```

--- a/specs/consumer_protocol.md
+++ b/specs/consumer_protocol.md
@@ -21,6 +21,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted as described in
 [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
+### ABNF (Augmented Backus-Naur Form)
+
+We use ABNF for the specification of content (e.g. messages & data frames).
+You can consult [RFC5234][abnf] for information about the grammar.
+
+[abnf]: https://tools.ietf.org/html/rfc5234
+
 ## Message stream
 
 The stream of messages exchanged between producer and consumer is

--- a/specs/json_payload.md
+++ b/specs/json_payload.md
@@ -19,7 +19,7 @@ The JSON body MUST be a hash. The contents of the hash depends on the
 message topic, which can take on the following values (see
 [producer_protocol](producer_protocol.md)).
 
-```
+```abnf
 topic = logs *( ALPHA / "." )            ; normal log messages
 topic /= javascript *( ALPHA / "." )     ; javascript errors
 topic /= events *( ALPHA / "." )         ; logjam event

--- a/specs/json_payload.md
+++ b/specs/json_payload.md
@@ -20,9 +20,9 @@ message topic, which can take on the following values (see
 [producer_protocol](producer_protocol.md)).
 
 ```abnf
-topic = logs *( ALPHA / "." )            ; normal log messages
-topic /= javascript *( ALPHA / "." )     ; javascript errors
-topic /= events *( ALPHA / "." )         ; logjam event
+topic = logs *( ALPHA / "." / "-" / "_" )            ; normal log messages
+topic /= javascript *( ALPHA / "." / "-" / "_" )     ; javascript errors
+topic /= events *( ALPHA / "." / "-" / "_" )         ; logjam event
 topic /= frontend.page                   ; frontend metric (page render)
 topic /= frontend.ajax                   ; frontend metric (ajax call)
 ```

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -148,6 +148,22 @@ sequence-number    = 8(OCTET)              ; uint64, network byte order
   millisecond resolution, but it is acceptable for the client to use a
   timer with second resolution to calculate this value.
 
+* All multi-byte sequences MUST be transferred in *network byte order* (a.k.a. Big
+  Endian; most significant byte first).
+
+## Additional information
+
+* Bit order requires no additional application level handling. Ethernet MAC frames
+  are defined to use LSB-0 (least significant bit first) and low level network
+  components should handle possible conversions from the host bit order to LSB-0
+  if necessary.
+
+  > Each octet of the MAC frame, with the exception of the FCS, is transmitted least significant bit first.
+
+  See (Section 3.3 in IEEE Standard for Ethernet," in IEEE Std 802.3-2018
+  (Revision of IEEE Std 802.3-2015) , vol., no., pp.123, 31 Aug. 2018, doi:
+  10.1109/IEEESTD.2018.8457469.)
+
 ## JSON payload requirements
 
 See companion document [json_payload](json_payload.md)

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -90,9 +90,9 @@ produced and a message sequence number.
 ```abnf
 data-msg = app-env topic json-body meta-info
 
-topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
-topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
-topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic = logs 1*( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript 1*( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events 1*( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
 topic /= frontend.page                                   ; frontend metric (page render)
 topic /= frontend.ajax                                   ; frontend metric (ajax call)
 topic /= mobile                                          ; mobile metric

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -103,13 +103,13 @@ meta-info = tag compression-method version device-number created-ms sequence-num
 
 tag = %xCA %xBD                                ; used internally to detect programming errors
 
-compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression
+compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression ; uint8
 no-compression     = %d0
 zlib-compression   = %d1
 snappy-compression = %d2
 lz4-compression    = %d3
 
-version            = %d1
+version            = %d1 ; uint8
 
 device-number      = 4(OCTET)              ; uint32, network byte order
 created-ms         = 8(OCTET)              ; uint64, network byte order

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -106,9 +106,9 @@ lz4-compression    = %d3
 
 version            = %d1
 
-device-number      = 4OCTET                ; uint32, network byte order
-created-ms         = 8OCTET                ; uint64, network byte order
-sequence-number    = 8OCTET                ; uint64, network byte order
+device-number      = 4(OCTET)              ; uint32, network byte order
+created-ms         = 8(OCTET)              ; uint64, network byte order
+sequence-number    = 8(OCTET)              ; uint64, network byte order
 ```
 
 ## Constraints

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -148,8 +148,9 @@ sequence-number    = 8(OCTET)              ; uint64, network byte order
   millisecond resolution, but it is acceptable for the client to use a
   timer with second resolution to calculate this value.
 
-* All multi-byte sequences MUST be transferred in *network byte order* (a.k.a. Big
-  Endian; most significant byte first).
+* All numeric multi-byte sequences MUST be transferred in *network byte order*
+  (a.k.a. Big Endian; most significant byte first). All other multi-byte
+  sequences MUST be transferred in order of appearance (left to right).
 
 ## Additional information
 

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -152,6 +152,9 @@ sequence-number    = 8(OCTET)              ; uint64, network byte order
   (a.k.a. Big Endian; most significant byte first). All other multi-byte
   sequences MUST be transferred in order of appearance (left to right).
 
+* The client MUST send a ping and await a pong before closing the underlying
+  connection, e.g. during shutdown.
+
 ## Additional information
 
 * Bit order requires no additional application level handling. Ethernet MAC frames

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -21,7 +21,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted as described in
 [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
+### ABNF (Augmented Backus-Naur Form)
 
+We use ABNF for the specification of content (e.g. messages & data frames).
+You can consult [RFC5234][abnf] for information about the grammar.
+
+[abnf]: https://tools.ietf.org/html/rfc5234
 
 ## Message stream
 

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -92,11 +92,11 @@ topic /= frontend.page                     ; frontend metric (page render)
 topic /= frontend.ajax                     ; frontend metric (ajax call)
 topic /= mobile                            ; mobile metric
 
-json-body = *OCTET                         ; JSON string, possibly compressed
+json-body = *OCTET                             ; JSON string, possibly compressed
 
 meta-info = tag compression-method version device-number created-ms sequence-number
 
-tag = %xCABD                               ; used internally to detect programming errors
+tag = %xCA %xBD                                ; used internally to detect programming errors
 
 compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression
 no-compression     = %d0

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -99,12 +99,12 @@ meta-info = tag compression-method version device-number created-ms sequence-num
 tag = %xCABD                               ; used internally to detect programming errors
 
 compression-method = no-compression / zlib-compression / snappy-compression / lz4-compression
-no-compression     = %x0
-zlib-compression   = %x1
-snappy-compression = %x2
-lz4-compression    = %x3
+no-compression     = %d0
+zlib-compression   = %d1
+snappy-compression = %d2
+lz4-compression    = %d3
 
-version            = %x1
+version            = %d1
 
 device-number      = 4OCTET                ; uint32, network byte order
 created-ms         = 8OCTET                ; uint64, network byte order

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -85,12 +85,12 @@ produced and a message sequence number.
 ```abnf
 data-msg = app-env topic json-body meta-info
 
-topic = logs *( "." ALPHA *ALPHA )         ; normal log messages
-topic /= javascript *( "." ALPHA *ALPHA )  ; javascript errors
-topic /= events *( "." ALPHA *ALPHA )      ; logjam event
-topic /= frontend.page                     ; frontend metric (page render)
-topic /= frontend.ajax                     ; frontend metric (ajax call)
-topic /= mobile                            ; mobile metric
+topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic /= frontend.page                                   ; frontend metric (page render)
+topic /= frontend.ajax                                   ; frontend metric (ajax call)
+topic /= mobile                                          ; mobile metric
 
 json-body = *OCTET                             ; JSON string, possibly compressed
 

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -90,9 +90,9 @@ produced and a message sequence number.
 ```abnf
 data-msg = app-env topic json-body meta-info
 
-topic = logs 1*( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
-topic /= javascript 1*( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
-topic /= events 1*( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
+topic = logs *( "." ALPHA *(ALPHA / "-" / "_") )         ; normal log messages
+topic /= javascript *( "." ALPHA *(ALPHA / "-" / "_") )  ; javascript errors
+topic /= events *( "." ALPHA *(ALPHA / "-" / "_") )      ; logjam event
 topic /= frontend.page                                   ; frontend metric (page render)
 topic /= frontend.ajax                                   ; frontend metric (ajax call)
 topic /= mobile                                          ; mobile metric

--- a/specs/producer_protocol.md
+++ b/specs/producer_protocol.md
@@ -31,7 +31,7 @@ information intended to specify that the following output is produced
 by the client and "S:" is used to mark server output. ZeroMQ frame
 delimiters are left out in order to simplify the presentation.
 
-```
+```abnf
 stream = *(request-reply / ping-pong / async-data)
 
 request-reply = C: request-msg S: reply-msg
@@ -82,7 +82,7 @@ finally a frame containing meta information, such as protocol version,
 compression method used for the JSON body, when the messages was
 produced and a message sequence number.
 
-```
+```abnf
 data-msg = app-env topic json-body meta-info
 
 topic = logs *( "." ALPHA *ALPHA )         ; normal log messages


### PR DESCRIPTION
The PR does the following:

* Enable ABNF highlighting
* Add ABNF info (with link to RFC)
* Allow `_` and `-` in topic segments (represents current reference implementation)
* Clarify that all numeric multi-byte sequences are sent in `network byte order`/Big Endian
* Clearly document `tag` as a concatenation of two specific OCTETS.
* Use decimal notation for number literals
* Document bit-order background (just to not need to do the research again)