### PR TITLE
Reorganise fhttpd code

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -34,8 +34,8 @@ logjam-livestream-generator: livestream-generator/generator.go
 logjam-http-forwarder: http-forwarder/forwarder.go util/util.go
 	go build -i -o $@ $<
 
-logjam-fhttpd: fhttpd/fhttpd.go util/util.go
-	go build -i -o $@ $<
+logjam-fhttpd: fhttpd/* util/util.go
+	go build -o $@ github.com/skaes/logjam-tools/go/fhttpd
 
 EXPORTER_PKGS = prometheusexporter/messageparser/messageparser.go prometheusexporter/collector/collector.go prometheusexporter/collectormanager/collectormanager.go prometheusexporter/webserver/webserver.go prometheusexporter/stats/stats.go
 EXPORTER_DEPS = util/util.go util/streams.go util/resources.go logging/logging.go frontendmetrics/frontendmetrics.go

--- a/go/Makefile
+++ b/go/Makefile
@@ -52,7 +52,7 @@ logjam-mongodb-restore: restore/restore.go
 logjam-rename-callers: rename-callers/rename-callers.go
 	go build -i -o $@ $<
 
-GO_TESTS = promcollector-test livestream-test util-test frontendmetrics-test
+GO_TESTS = promcollector-test livestream-test util-test frontendmetrics-test fhttpd-test
 .PHONY: $(GO_TESTS)
 check: $(GO_TESTS)
 
@@ -70,3 +70,6 @@ util-test:
 
 frontendmetrics-test: frontendmetrics/*.go
 	go test ./frontendmetrics
+
+fhttpd-test: fhttpd/*
+	go test ./fhttpd

--- a/go/fhttpd/fhttpd.go
+++ b/go/fhttpd/fhttpd.go
@@ -36,7 +36,7 @@ var (
 	outputSpec  string
 	compression byte
 
-	publisher *pub.Publisher
+	publisher pub.Publisher
 
 	// Zeromq PUB sockets are not thread safe, so we run the publisher in a
 	// separate go routine.

--- a/go/fhttpd/fhttpd.go
+++ b/go/fhttpd/fhttpd.go
@@ -9,10 +9,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	// _ "net/http/pprof"
@@ -282,13 +280,6 @@ func shutdownWebServer(srv *http.Server, gracePeriod time.Duration) {
 // 	fmt.Println(http.ListenAndServe(debugSpec, nil))
 // }
 
-func waitForInterrupt() {
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	<-done
-	log.Info("received interrupt")
-}
-
 func main() {
 	log.Info("%s starting", os.Args[0])
 	parseArgs()
@@ -320,7 +311,10 @@ func main() {
 
 	srv := setupWebServer()
 	go runWebServer(srv)
-	waitForInterrupt()
+
+	util.WaitForInterrupt()
+	log.Info("received interrupt")
+
 	shutdownWebServer(srv, 5*time.Second)
 
 	// Wait for publisher and stats reporter to finsh.

--- a/go/fhttpd/fhttpd.go
+++ b/go/fhttpd/fhttpd.go
@@ -49,7 +49,7 @@ var (
 	// separate go routine.
 )
 
-func initialize() {
+func parseArgs() {
 	args, err := flags.ParseArgs(&opts, os.Args)
 	if err != nil {
 		e := err.(*flags.Error)
@@ -291,7 +291,7 @@ func waitForInterrupt() {
 
 func main() {
 	log.Info("%s starting", os.Args[0])
-	initialize()
+	parseArgs()
 	outputSpec = fmt.Sprintf("tcp://*:%d", opts.OutputPort)
 	verbose = opts.Verbose
 	quiet = opts.Quiet

--- a/go/fhttpd/frontendrequests.go
+++ b/go/fhttpd/frontendrequests.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/skaes/logjam-tools/go/util"
+)
+
+func serveFrontendRequest(w http.ResponseWriter, r *http.Request) {
+	defer recordRequestStats(r)
+	sm, rid, err := extractFrontendData(r)
+	if err != nil {
+		writeErrorResponse(w, err.Error())
+		return
+	}
+	msgType := extractFrontendMsgType(r)
+	err = sendFrontendData(rid, msgType, sm)
+	if err != nil {
+		writeErrorResponse(w, err.Error())
+		return
+	}
+	writeImageResponse(w)
+}
+
+func extractFrontendData(r *http.Request) (stringMap, *util.RequestId, error) {
+	sm, err := parseQuery(r)
+	if err != nil {
+		return sm, nil, err
+	}
+	// add timestamps
+	now := time.Now()
+	sm["started_ms"] = now.UnixNano() / int64(time.Millisecond)
+	sm["started_at"] = now.Format(time.RFC3339)
+
+	// check protocol version
+	if sm["v"] == nil {
+		return sm, nil, errors.New("Missing protocol version number: v=1")
+	}
+	if sm["v"].(int) != 1 {
+		return sm, nil, fmt.Errorf("Unsupported protocol version: v=%d", sm["v"].(int))
+	}
+	// check logjam_action
+	if sm["logjam_action"] == nil {
+		return sm, nil, errors.New("Missing field: logjam_action")
+	}
+	// check request_id
+	if sm["logjam_request_id"] == nil {
+		return sm, nil, errors.New("Missing field: logjam_request_id")
+	}
+	id := sm["logjam_request_id"].(string)
+	// extract app and environment
+	rid, err := util.ParseRequestId(id)
+	if err != nil {
+		return sm, nil, err
+	}
+	sm["user_agent"] = r.Header.Get("User-Agent")
+	// log.Info("SM: %+v, RID: %+v", sm, rid)
+	return sm, rid, nil
+}
+
+func extractFrontendMsgType(r *http.Request) string {
+	if r.URL.Path == "/logjam/ajax" {
+		return "ajax"
+	}
+	if r.URL.Path == "/logjam/page" {
+		return "page"
+	}
+	return "unknown"
+}
+
+func sendFrontendData(rid *util.RequestId, msgType string, sm stringMap) error {
+	appEnv := rid.AppEnv()
+	routingKey := rid.RoutingKey("frontend", msgType)
+	data, err := json.Marshal(sm)
+	if err != nil {
+		return err
+	}
+	publisher.Publish(appEnv, routingKey, data, util.NoCompression)
+	return nil
+}

--- a/go/fhttpd/frontendrequests.go
+++ b/go/fhttpd/frontendrequests.go
@@ -26,13 +26,15 @@ func serveFrontendRequest(w http.ResponseWriter, r *http.Request) {
 	writeImageResponse(w)
 }
 
+var nowFunc = time.Now
+
 func extractFrontendData(r *http.Request) (stringMap, *util.RequestId, error) {
 	sm, err := parseQuery(r)
 	if err != nil {
 		return sm, nil, err
 	}
 	// add timestamps
-	now := time.Now()
+	now := nowFunc()
 	sm["started_ms"] = now.UnixNano() / int64(time.Millisecond)
 	sm["started_at"] = now.Format(time.RFC3339)
 

--- a/go/fhttpd/frontendrequests_test.go
+++ b/go/fhttpd/frontendrequests_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/skaes/logjam-tools/go/util"
+	"github.com/stretchr/testify/assert"
+
+	dummypub "github.com/skaes/logjam-tools/go/publisher/testhelper"
+)
+
+func TestSendFrontendData(t *testing.T) {
+	publisher = dummypub.NewDummyPublisher()
+	rid, err := util.ParseRequestId("some-app-preview-55ff333eee")
+	assert.NoError(t, err, "we passed a valid request id, it should not fail")
+	msgType := "unknown"
+	sm := stringMap{
+		"foo": "bar",
+	}
+	marshaledSM, _ := json.Marshal(sm)
+
+	err = sendFrontendData(rid, msgType, sm)
+	assert.NoError(t, err)
+	assert.Equal(t, []dummypub.DummyMessage{
+		{
+			AppEnv:         "some-app-preview",
+			RoutingKey:     "frontend.unknown.some-app.preview",
+			Data:           marshaledSM,
+			CompressedWith: 0,
+		},
+	}, publisher.(*dummypub.DummyPublisher).PublishedMessages)
+}
+
+func TestExtractFrontendMsgType(t *testing.T) {
+	t.Run("Recognizes ajax", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/ajax")
+		req := &http.Request{
+			URL: uri,
+		}
+		msgType := extractFrontendMsgType(req)
+		assert.Equal(t, "ajax", msgType)
+	})
+	t.Run("Recognizes page", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		req := &http.Request{
+			URL: uri,
+		}
+		msgType := extractFrontendMsgType(req)
+		assert.Equal(t, "page", msgType)
+	})
+	t.Run("Defaults to unknown", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/something")
+		req := &http.Request{
+			URL: uri,
+		}
+		msgType := extractFrontendMsgType(req)
+		assert.Equal(t, "unknown", msgType)
+	})
+}
+
+func TestExtractFrontendData(t *testing.T) {
+	now := time.Now()
+	nowFunc = func() time.Time { return now }
+
+	action := "myActions#call"
+	requestId := "some-app-preview-55ff333eee"
+	userAgent := "testing/testing logjam-tools"
+
+	t.Run("SuccessfulExtraction", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		query := uri.Query()
+		query.Set("v", "1")
+		query.Set("logjam_action", action)
+		query.Set("logjam_request_id", requestId)
+		uri.RawQuery = query.Encode()
+		headers := http.Header{}
+		headers.Add("user-agent", userAgent)
+		req := &http.Request{
+			Method: "GET",
+			URL:    uri,
+			Header: headers,
+		}
+
+		payload, logjamRequestId, err := extractFrontendData(req)
+		assert.NoError(t, err)
+
+		assert.NotNil(t, logjamRequestId)
+
+		expectedPayload := stringMap{
+			"started_ms":        now.UnixNano() / int64(time.Millisecond),
+			"started_at":        now.Format(time.RFC3339),
+			"v":                 1,
+			"logjam_action":     action,
+			"logjam_request_id": requestId,
+			"user_agent":        userAgent,
+		}
+		assert.Equal(t, expectedPayload, payload)
+	})
+
+	t.Run("MissingProtocolVersion", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		query := uri.Query()
+		query.Set("logjam_action", action)
+		query.Set("logjam_request_id", requestId)
+		uri.RawQuery = query.Encode()
+		headers := http.Header{}
+		headers.Add("user-agent", userAgent)
+		req := &http.Request{
+			Method: "GET",
+			URL:    uri,
+			Header: headers,
+		}
+
+		_, logjamRequestId, err := extractFrontendData(req)
+		assert.EqualError(t, err, "Missing protocol version number: v=1")
+		assert.Nil(t, logjamRequestId)
+	})
+
+	t.Run("UnsupportedProtocolVersion", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		query := uri.Query()
+		query.Set("v", "2")
+		query.Set("logjam_action", action)
+		query.Set("logjam_request_id", requestId)
+		uri.RawQuery = query.Encode()
+		headers := http.Header{}
+		headers.Add("user-agent", userAgent)
+		req := &http.Request{
+			Method: "GET",
+			URL:    uri,
+			Header: headers,
+		}
+
+		_, logjamRequestId, err := extractFrontendData(req)
+		assert.EqualError(t, err, "Unsupported protocol version: v=2")
+		assert.Nil(t, logjamRequestId)
+	})
+
+	t.Run("MissingLogjamAction", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		query := uri.Query()
+		query.Set("v", "1")
+		query.Set("logjam_request_id", requestId)
+		uri.RawQuery = query.Encode()
+		headers := http.Header{}
+		headers.Add("user-agent", userAgent)
+		req := &http.Request{
+			Method: "GET",
+			URL:    uri,
+			Header: headers,
+		}
+
+		_, logjamRequestId, err := extractFrontendData(req)
+		assert.EqualError(t, err, "Missing field: logjam_action")
+		assert.Nil(t, logjamRequestId)
+	})
+
+	t.Run("MissingLogjamRequestId", func(t *testing.T) {
+		uri, _ := url.Parse("https://logjam.example.com/logjam/page")
+		query := uri.Query()
+		query.Set("v", "1")
+		query.Set("logjam_action", action)
+		uri.RawQuery = query.Encode()
+		headers := http.Header{}
+		headers.Add("user-agent", userAgent)
+		req := &http.Request{
+			Method: "GET",
+			URL:    uri,
+			Header: headers,
+		}
+
+		_, logjamRequestId, err := extractFrontendData(req)
+		assert.EqualError(t, err, "Missing field: logjam_request_id")
+		assert.Nil(t, logjamRequestId)
+	})
+}

--- a/go/fhttpd/http.go
+++ b/go/fhttpd/http.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/skaes/logjam-tools/go/logging"
+)
+
+func runWebServer(srv *http.Server) {
+	log.Info("starting http server on %s", srv.Addr)
+	if opts.KeyFile != "" && opts.CertFile != "" {
+		err := srv.ListenAndServeTLS(opts.CertFile, opts.KeyFile)
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("Cannot listen and serve TLS: %s", err)
+		}
+	} else if opts.KeyFile != "" {
+		log.Error("cert-file given but no key-file!")
+	} else if opts.CertFile != "" {
+		log.Error("key-file given but no cert-file!")
+	} else {
+		err := srv.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("Cannot listen and serve: %s", err)
+		}
+	}
+}
+
+func shutdownWebServer(srv *http.Server, gracePeriod time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	defer cancel()
+	err := srv.Shutdown(ctx)
+	if err != nil {
+		log.Error("web server shutdown failed: %+v", err)
+	} else {
+		log.Info("web server shutdown successful")
+	}
+}
+
+type (
+	stringMap map[string]interface{}
+	stringSet map[string]bool
+)
+
+func (sm stringMap) DeleteString(k string) string {
+	v, _ := sm[k].(string)
+	delete(sm, k)
+	return v
+}
+
+// URL params which neeed to be converted to integer for JSON
+var integerKeyList = []string{"viewport_height", "viewport_width", "html_nodes", "script_nodes", "style_nodes", "v"}
+
+// Lookup table for those params
+var integerKeys stringSet
+
+func init() {
+	integerKeys = make(stringSet)
+	for _, k := range integerKeyList {
+		integerKeys[k] = true
+	}
+}
+
+func parseValue(k string, v string) (interface{}, error) {
+	if integerKeys[k] {
+		return strconv.Atoi(v)
+	}
+	return v, nil
+}
+
+func parseQuery(r *http.Request) (stringMap, error) {
+	sm := make(stringMap)
+	for k, v := range r.URL.Query() {
+		switch len(v) {
+		case 1:
+			v, err := parseValue(k, v[0])
+			if err != nil {
+				return sm, err
+			}
+			sm[k] = v
+		case 0:
+			sm[k] = ""
+		default:
+			return sm, fmt.Errorf("Parameter %s specified more than once", k)
+		}
+	}
+	return sm, nil
+}
+
+func writeErrorResponse(w http.ResponseWriter, txt string) {
+	statsMutex.Lock()
+	httpFailures++
+	statsMutex.Unlock()
+	http.Error(w, "400 RTFM", 400)
+	fmt.Fprintln(w, txt)
+}
+
+func writeImageResponse(w http.ResponseWriter) {
+	w.WriteHeader(200)
+	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Content-Type", "image/gif")
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Content-Transfer-Encoding", "base64")
+	io.WriteString(w, "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
+}
+
+func serveAlive(w http.ResponseWriter, r *http.Request) {
+	defer recordRequestStats(r)
+	w.WriteHeader(200)
+	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Content-Type", "text/plain")
+	io.WriteString(w, "ALIVE\n")
+}

--- a/go/fhttpd/mobilerequests.go
+++ b/go/fhttpd/mobilerequests.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/skaes/logjam-tools/go/util"
+)
+
+func serveMobileMetrics(w http.ResponseWriter, r *http.Request) {
+	defer recordRequestStats(r)
+	bytes, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		writeErrorResponse(w, err.Error())
+		return
+	}
+	appEnv := "mobile-production"
+	routingKey := "mobile"
+	publisher.Publish(appEnv, routingKey, bytes, util.NoCompression)
+	writeImageResponse(w)
+}

--- a/go/fhttpd/stats.go
+++ b/go/fhttpd/stats.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/skaes/logjam-tools/go/logging"
+	"github.com/skaes/logjam-tools/go/util"
+)
+
+var (
+	// Statistics variables protected by a mutex.
+	statsMutex        = &sync.Mutex{}
+	processedCount    uint64
+	processedBytes    uint64
+	processedMaxBytes uint64
+	httpFailures      uint64
+)
+
+// report number of processed requests every second
+func statsReporter() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for !util.Interrupted() {
+		<-ticker.C
+		// obtain values and reset counters
+		statsMutex.Lock()
+		count := processedCount
+		bytes := processedBytes
+		maxBytes := processedMaxBytes
+		failures := httpFailures
+		processedCount = 0
+		processedBytes = 0
+		processedMaxBytes = 0
+		httpFailures = 0
+		statsMutex.Unlock()
+		// report
+		kb := float64(bytes) / 1024.0
+		maxkb := float64(maxBytes) / 1024.0
+		var avgkb float64
+		if count > 0 {
+			avgkb = kb / float64(count)
+		}
+		if !quiet {
+			log.Info("processed %d, invalid %d, size: %.2f KB, avg: %.2f KB, max: %.2f", count, failures, kb, avgkb, maxkb)
+		}
+	}
+}
+
+// No thanks to https://github.com/golang/go/issues/19644, this is only an
+// approximation of the actual number of bytes transferred.
+func requestSize(r *http.Request) uint64 {
+	size := uint64(len(r.URL.String()))
+	for k, values := range r.Header {
+		l := len(k)
+		for _, v := range values {
+			size += uint64(l + len(v) + 4) // k: v\r\n
+		}
+	}
+	if r.ContentLength > 0 {
+		size += uint64(r.ContentLength)
+	}
+	return size
+}
+
+func recordRequestStats(r *http.Request) {
+	size := requestSize(r)
+	statsMutex.Lock()
+	processedCount++
+	processedBytes += size
+	if processedMaxBytes < size {
+		processedMaxBytes = size
+	}
+	statsMutex.Unlock()
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/prometheus/common v0.0.0-20181015124227-bcb74de08d37 // indirect
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d // indirect
 	github.com/smartystreets/goconvey v1.6.4
+	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.2
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect

--- a/go/http-forwarder/forwarder.go
+++ b/go/http-forwarder/forwarder.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
 	// _ "net/http/pprof"
 
 	"github.com/gorilla/mux"
@@ -44,7 +45,7 @@ var (
 	outputSpec  string
 	compression byte
 
-	publisher *pub.Publisher
+	publisher pub.Publisher
 
 	// Statistics variables protected by a mutex.
 	statsMutex        = &sync.Mutex{}

--- a/go/publisher/testhelper/dummypublisher.go
+++ b/go/publisher/testhelper/dummypublisher.go
@@ -1,0 +1,27 @@
+package testhelper
+
+type DummyPublisher struct {
+	PublishedMessages []DummyMessage
+}
+
+type DummyMessage struct {
+	AppEnv         string
+	RoutingKey     string
+	Data           []byte
+	CompressedWith uint8
+}
+
+func NewDummyPublisher() *DummyPublisher {
+	return &DummyPublisher{
+		PublishedMessages: []DummyMessage{},
+	}
+}
+
+func (p *DummyPublisher) Publish(appEnv string, routingKey string, data []byte, compressedWith uint8) {
+	p.PublishedMessages = append(p.PublishedMessages, DummyMessage{
+		AppEnv:         appEnv,
+		RoutingKey:     routingKey,
+		Data:           data,
+		CompressedWith: compressedWith,
+	})
+}

--- a/go/util/util.go
+++ b/go/util/util.go
@@ -199,6 +199,13 @@ func Interrupted() bool {
 	return atomic.LoadUint32(&interrupted) == 1
 }
 
+// Installs its own signal handler and waits for interrupts and TERM signal
+func WaitForInterrupt() {
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+	<-done
+}
+
 // ParseCompressionMethodName converts string to compression method
 func ParseCompressionMethodName(name string) (method uint8, err error) {
 	switch name {


### PR DESCRIPTION
The purpose of the PR is to reorganise the code belonging to fhttpd into separate files organised by purpose.

The fhttpd.go was growing quite large and it wasn't immediately apparent what the relevant parts for adding or changing business logic were. Now there are two files "frontendrequests.go" and "mobilerequests.go" representing the core handling for those two requests types.

It hopefully makes it easier to contribute the new third type: "webvitals".