### PR TITLE
define webvitals type in a new package

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -52,7 +52,7 @@ logjam-mongodb-restore: restore/restore.go
 logjam-rename-callers: rename-callers/rename-callers.go
 	go build -i -o $@ $<
 
-GO_TESTS = promcollector-test livestream-test util-test frontendmetrics-test fhttpd-test
+GO_TESTS = promcollector-test livestream-test util-test frontendmetrics-test fhttpd-test formats-test
 .PHONY: $(GO_TESTS)
 check: $(GO_TESTS)
 
@@ -73,3 +73,6 @@ frontendmetrics-test: frontendmetrics/*.go
 
 fhttpd-test: fhttpd/*
 	go test ./fhttpd
+
+formats-test: formats/*
+	go test ./formats/*

--- a/go/formats/webvitals/webvitals.go
+++ b/go/formats/webvitals/webvitals.go
@@ -1,0 +1,19 @@
+package webvitals
+
+const RoutingKeyPrefix = "frontend"
+const RoutingKeyMsgType = "webvitals"
+
+// WebVitals is the representation of WebVitals metrics
+// in the Payload of a Logjam Message.
+type WebVitals struct {
+	LogjamRequestId string   `json:"logjam_request_id"`
+	LogjamAction    string   `json:"logjam_action"`
+	Metrics         []Metric `json:"metrics"`
+}
+
+type Metric struct {
+	Id  string   `json:"id"`
+	LCP *float64 `json:"lcp,omitempty"`
+	FID *float64 `json:"fid,omitempty"`
+	CLS *float64 `json:"cls,omitempty"`
+}

--- a/go/formats/webvitals/webvitals_test.go
+++ b/go/formats/webvitals/webvitals_test.go
@@ -1,0 +1,36 @@
+package webvitals
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebVitalsMarshaling(t *testing.T) {
+	rid := "some-app-preview-55ff333eee"
+	fid := 0.24
+	webVitals := &WebVitals{
+		LogjamAction:    "someAction#call",
+		LogjamRequestId: rid,
+		Metrics: []Metric{
+			{
+				Id:  "1",
+				FID: &fid,
+			},
+		},
+	}
+
+	result := &WebVitals{}
+
+	marshaled, err := json.Marshal(webVitals)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(marshaled, result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, webVitals, result)
+
+	assert.Nil(t, result.Metrics[0].LCP)
+	assert.Nil(t, result.Metrics[0].CLS)
+}


### PR DESCRIPTION
That way the type can be reused on the consumer side (if it is written in go
such as the logjam-prometheus-exporter).