### PR TITLE
Support browser data in webvitals

### DIFF
--- a/go/fhttpd/webvitals/webvitals.go
+++ b/go/fhttpd/webvitals/webvitals.go
@@ -70,6 +70,7 @@ func extractWebVitals(r *http.Request) (*format.WebVitals, *util.RequestId, erro
 	now := nowFunc()
 	webVitals.StartedMs = now.UnixNano() / int64(time.Millisecond)
 	webVitals.StartedAt = now.Format(time.RFC3339)
+	webVitals.UserAgent = r.UserAgent()
 
 	return webVitals, requestId, nil
 }

--- a/go/formats/webvitals/webvitals.go
+++ b/go/formats/webvitals/webvitals.go
@@ -13,6 +13,8 @@ type WebVitals struct {
 	// a field that should be supplied via the WebVitals endpoint.
 	StartedAt string `json:"started_at" form:"-"`
 
+	UserAgent string `json:"user_agent" form:"-"`
+
 	LogjamRequestId string   `json:"logjam_request_id" form:"logjam_request_id"`
 	LogjamAction    string   `json:"logjam_action" form:"logjam_action"`
 	Metrics         []Metric `json:"metrics" form:"metrics"`

--- a/go/formats/webvitals/webvitals.go
+++ b/go/formats/webvitals/webvitals.go
@@ -8,29 +8,29 @@ const RoutingKeyMsgType = "webvitals"
 type WebVitals struct {
 	// StartedMs is filled in server side by us and not a field that should be
 	// supplied via the WebVitals endpoint.
-	StartedMs int64 `json:"started_ms" form:"-"`
+	StartedMs int64 `json:"started_ms" form:"-" mapstructure:"started_ms"`
 	// StartedAt is filled in server side by us (As an RFC3339 timestamp) and not
 	// a field that should be supplied via the WebVitals endpoint.
-	StartedAt string `json:"started_at" form:"-"`
+	StartedAt string `json:"started_at" form:"-" mapstructure:"started_at"`
 
-	UserAgent string `json:"user_agent" form:"-"`
+	UserAgent string `json:"user_agent" form:"-" mapstructure:"user_agent"`
 
-	LogjamRequestId string   `json:"logjam_request_id" form:"logjam_request_id"`
-	LogjamAction    string   `json:"logjam_action" form:"logjam_action"`
+	LogjamRequestId string   `json:"logjam_request_id" form:"logjam_request_id" mapstructure:"logjam_request_id"`
+	LogjamAction    string   `json:"logjam_action" form:"logjam_action" mapstructure:"logjam_action"`
 	Metrics         []Metric `json:"metrics" form:"metrics"`
 }
 
 // Metric represents a single measurement of a single metric
 // Only one of LCP, FID or CLS should be set
 type Metric struct {
-	Id string `json:"id" form:"id"`
+	Id string `json:"id" form:"id" mapstructure:"id"`
 
 	// LCP (Largest Contentful Paint) is a latency measurement in milliseconds
-	LCP *float64 `json:"lcp,omitempty" form:"lcp"`
+	LCP *float64 `json:"lcp,omitempty" form:"lcp" mapstructure:"lcp"`
 
 	// FID (First Input Delay) is a latency measurement in milliseconds
-	FID *float64 `json:"fid,omitempty" form:"fid"`
+	FID *float64 `json:"fid,omitempty" form:"fid" mapstructure:"fid"`
 
 	// CLS (Cumulative Layout Shift) is a score represented as a float between 0 and 1
-	CLS *float64 `json:"cls,omitempty" form:"cls"`
+	CLS *float64 `json:"cls,omitempty" form:"cls" mapstructure:"cls"`
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,6 +3,7 @@ module github.com/skaes/logjam-tools/go
 require (
 	github.com/ShowMax/go-fqdn v0.0.0-20180501083314-6f60894d629f
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-playground/form/v4 v4.1.3
 	github.com/gogo/protobuf v1.1.1 // indirect
@@ -24,6 +25,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.3.0
 	github.com/xdg/stringprep v1.0.0 // indirect
+	github.com/xojoc/useragent v0.0.0-20200116211053-1ec61d55e8fe
 	go.mongodb.org/mongo-driver v1.3.2
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/text v0.3.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -3,6 +3,8 @@ github.com/ShowMax/go-fqdn v0.0.0-20180501083314-6f60894d629f h1:JXCLW7P0nQ6aNQk
 github.com/ShowMax/go-fqdn v0.0.0-20180501083314-6f60894d629f/go.mod h1:Wbphg/zwBzq1nUotnHP8day9iRhcMOwh7JFW1vkzq6w=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -119,6 +121,8 @@ github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhe
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
+github.com/xojoc/useragent v0.0.0-20200116211053-1ec61d55e8fe h1:wZvowxeQDplr0N50mtaKc6Y3vF7CvJTreA2eo1FtIi4=
+github.com/xojoc/useragent v0.0.0-20200116211053-1ec61d55e8fe/go.mod h1:3SrcTmgUCXqpF8A4rZ3IPvnRzvwWqNFNqtSJ19P94g4=
 go.mongodb.org/mongo-driver v1.3.2 h1:IYppNjEV/C+/3VPbhHVxQ4t04eVW0cLp0/pNdW++6Ug=
 go.mongodb.org/mongo-driver v1.3.2/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/go/prometheusexporter/collector/collector_test.go
+++ b/go/prometheusexporter/collector/collector_test.go
@@ -1,12 +1,12 @@
 package collector
 
 import (
-	"reflect"
 	"sync"
 	"testing"
 
 	"github.com/skaes/logjam-tools/go/formats/webvitals"
 	"github.com/skaes/logjam-tools/go/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractingMetricNames(t *testing.T) {
@@ -155,14 +155,19 @@ func TestExtractingSingleWebVital(t *testing.T) {
 	got := c.processWebVitalsMessage(rk, data)
 	wantedlcp := 1.3
 	want := &metric{
-		kind: 4, props: map[string]string{"app": "some-app", "env": "preview", "action": "someAction#call"},
+		kind: 4, props: map[string]string{
+			"app":         "some-app",
+			"env":         "preview",
+			"action":      "someAction#call",
+			"browser":     "unknown",
+			"device_type": "unknown",
+		},
 		webvitals: []webvitals.Metric{{LCP: &wantedlcp}},
 	}
 
-	if !reflect.DeepEqual(*got, *want) {
-		t.Errorf("Collector.processWebVitalsMessage() got= %v, want %v", *got, *want)
-	}
+	assert.Equal(t, want, got)
 }
+
 func TestExtractingMultiWebVitals(t *testing.T) {
 
 	s := util.Stream{
@@ -193,13 +198,100 @@ func TestExtractingMultiWebVitals(t *testing.T) {
 	wantedlcp := 1.3
 	wantedcls := 0.42
 	want := &metric{
-		kind: 4, props: map[string]string{"app": "some-app", "env": "preview", "action": "someAction#call"},
-		webvitals: []webvitals.Metric{{FID: &wantedfid}, {LCP: &wantedlcp}, {CLS: &wantedcls}},
+		kind: 4, props: map[string]string{
+			"app":         "some-app",
+			"env":         "preview",
+			"action":      "someAction#call",
+			"browser":     "unknown",
+			"device_type": "unknown",
+		},
+		webvitals: []webvitals.Metric{
+			{FID: &wantedfid},
+			{LCP: &wantedlcp},
+			{CLS: &wantedcls},
+		},
 	}
 
-	if !reflect.DeepEqual(*got, *want) {
-		t.Errorf("Collector.processWebVitalsMessage() got= %v, want %v", *got, *want)
+	assert.Equal(t, want, got)
+}
+
+func TestWebVitalsWithUserAgent(t *testing.T) {
+	s := util.Stream{
+		App:                 "some-app",
+		Env:                 "preview",
+		IgnoredRequestURI:   "/_",
+		BackendOnlyRequests: "",
+		APIRequests:         []string{},
 	}
+	options := Options{
+		Datacenters: "a,b",
+		CleanAfter:  60,
+		Resources: &util.Resources{
+			TimeResources: []string{"db_time"},
+			CallResources: []string{"db_calls"},
+		},
+	}
+	c := New(s.AppEnv(), &s, options)
+
+	t.Run("ForOpera", func(t *testing.T) {
+		rk := "webvitals"
+		data := make(map[string]interface{})
+		data["logjam_request_id"] = "some-app-preview-55fffeee333"
+		data["logjam_action"] = "someAction#call"
+		data["user_agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36 OPR/76.0.4017.94"
+		data["metrics"] = []map[string]float64{{"fid": 0.24}, {"lcp": 1.3}, {"cls": 0.42}}
+
+		got := c.processWebVitalsMessage(rk, data)
+		wantedfid := 0.24
+		wantedlcp := 1.3
+		wantedcls := 0.42
+		want := &metric{
+			kind: 4, props: map[string]string{
+				"app":         "some-app",
+				"env":         "preview",
+				"action":      "someAction#call",
+				"browser":     "Opera",
+				"device_type": "desktop",
+			},
+			webvitals: []webvitals.Metric{
+				{FID: &wantedfid},
+				{LCP: &wantedlcp},
+				{CLS: &wantedcls},
+			},
+		}
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("ForChrome", func(t *testing.T) {
+		rk := "webvitals"
+		data := make(map[string]interface{})
+		data["logjam_request_id"] = "some-app-preview-55fffeee333"
+		data["logjam_action"] = "someAction#call"
+		data["user_agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"
+		data["metrics"] = []map[string]float64{{"fid": 0.24}, {"lcp": 1.3}, {"cls": 0.42}}
+
+		got := c.processWebVitalsMessage(rk, data)
+		wantedfid := 0.24
+		wantedlcp := 1.3
+		wantedcls := 0.42
+		want := &metric{
+			kind: 4, props: map[string]string{
+				"app":         "some-app",
+				"env":         "preview",
+				"action":      "someAction#call",
+				"browser":     "Chrome",
+				"device_type": "desktop",
+			},
+			webvitals: []webvitals.Metric{
+				{FID: &wantedfid},
+				{LCP: &wantedlcp},
+				{CLS: &wantedcls},
+			},
+		}
+
+		assert.Equal(t, want, got)
+	})
 }
 
 var m sync.Mutex


### PR DESCRIPTION
This adds two browser/client related labels to the webvitals metrics:

* `browser` representing the name of a browser (such as "Chrome" or "Firefox", will be set to "unknown" if the UserAgent could not be parsed)
* `device_type` representing the type of device the browser is running in (such as "desktop", "mobile", "tablet", will be set to "unknown" if the UserAgent could not be parsed).