### PR TITLE
fhttpd: correct invalid action names received on webvitals endpoint

### DIFF
--- a/go/fhttpd/webvitals/webvitals.go
+++ b/go/fhttpd/webvitals/webvitals.go
@@ -92,7 +92,7 @@ func publishWebVitals(publisher pub.Publisher, rid *util.RequestId, payload *for
 const UnknownAction = "Unknown#unknown_method"
 
 // ValidActionRegex is used to check for invalid action names
-var ValidActionRegex = regexp.MustCompile(`\A([^:'"#]+::)*[^:'"#]+#[^:'"#]+\z`)
+var ValidActionRegex = regexp.MustCompile(`\A([^:#\s]+::)*[^:#\s]+#get+\z`)
 
 func correctInvalidActionName(action string) string {
 	if !ValidActionRegex.Match([]byte(action)) {

--- a/go/fhttpd/webvitals/webvitals.go
+++ b/go/fhttpd/webvitals/webvitals.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	form "github.com/go-playground/form/v4"
@@ -95,8 +96,9 @@ const UnknownAction = "Unknown#unknown_method"
 var ValidActionRegex = regexp.MustCompile(`\A([^:#\s]+::)*[^:#\s]+#get+\z`)
 
 func correctInvalidActionName(action string) string {
-	if !ValidActionRegex.Match([]byte(action)) {
+	s := strings.TrimLeft(action, ":")
+	if !ValidActionRegex.Match([]byte(s)) {
 		return UnknownAction
 	}
-	return action
+	return s
 }

--- a/go/fhttpd/webvitals/webvitals_test.go
+++ b/go/fhttpd/webvitals/webvitals_test.go
@@ -51,7 +51,7 @@ func TestExtractWebVitals(t *testing.T) {
 	now := time.Now()
 	nowFunc = func() time.Time { return now }
 
-	action := "myActions#call"
+	action := "myActions#get"
 	rid := "some-app-preview-55ff333eee"
 
 	fid := 0.24
@@ -119,7 +119,7 @@ func TestServe(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 
 	t.Run("With query string", func(t *testing.T) {
-		action := "myActions#call"
+		action := "myActions#get"
 		rid := "some-app-preview-55ff333eee"
 
 		fid := 0.24
@@ -166,8 +166,8 @@ func TestServe(t *testing.T) {
 	})
 
 	t.Run("With invalid request id", func(t *testing.T) {
-		action := "myActions#call"
-		rid := "some-eee"
+		action := "myActions#get"
+		rid := "some-invalidrid"
 
 		fid := 0.24
 		expectedWebVitals := &format.WebVitals{
@@ -215,12 +215,13 @@ func TestActionNameCorrection(t *testing.T) {
 		{input: `!!!`, want: UnknownAction},
 		{input: `Abc`, want: UnknownAction},
 		{input: `Abc#def#geh`, want: UnknownAction},
-		{input: `Abc#x`, want: `Abc#x`},
-		{input: `abc::def#x`, want: `abc::def#x`},
-		{input: `a'b#x`, want: UnknownAction},
-		{input: `ab#'x`, want: UnknownAction},
-		{input: `a"b#x`, want: UnknownAction},
-		{input: `ab#"x`, want: UnknownAction},
+		{input: `Abc#get`, want: `Abc#get`},
+		{input: `abc::def#get`, want: `abc::def#get`},
+		{input: `a:b#x`, want: UnknownAction},
+		{input: `ab#:x`, want: UnknownAction},
+		{input: `a:b#x`, want: UnknownAction},
+		{input: `ab##x`, want: UnknownAction},
+		{input: `a b#get`, want: UnknownAction},
 	}
 	for _, testCase := range testCases {
 		assert.Equal(t, testCase.want, correctInvalidActionName(testCase.input))

--- a/go/fhttpd/webvitals/webvitals_test.go
+++ b/go/fhttpd/webvitals/webvitals_test.go
@@ -222,6 +222,7 @@ func TestActionNameCorrection(t *testing.T) {
 		{input: `a:b#x`, want: UnknownAction},
 		{input: `ab##x`, want: UnknownAction},
 		{input: `a b#get`, want: UnknownAction},
+		{input: `::murks#get`, want: `murks#get`},
 	}
 	for _, testCase := range testCases {
 		assert.Equal(t, testCase.want, correctInvalidActionName(testCase.input))

--- a/go/fhttpd/webvitals/webvitals_test.go
+++ b/go/fhttpd/webvitals/webvitals_test.go
@@ -203,3 +203,26 @@ func TestServe(t *testing.T) {
 		assert.Equal(t, []dummypub.DummyMessage{}, publisher.PublishedMessages)
 	})
 }
+
+func TestActionNameCorrection(t *testing.T) {
+	type test struct {
+		input string
+		want  string
+	}
+	testCases := []test{
+		{input: ``, want: UnknownAction},
+		{input: `#`, want: UnknownAction},
+		{input: `!!!`, want: UnknownAction},
+		{input: `Abc`, want: UnknownAction},
+		{input: `Abc#def#geh`, want: UnknownAction},
+		{input: `Abc#x`, want: `Abc#x`},
+		{input: `abc::def#x`, want: `abc::def#x`},
+		{input: `a'b#x`, want: UnknownAction},
+		{input: `ab#'x`, want: UnknownAction},
+		{input: `a"b#x`, want: UnknownAction},
+		{input: `ab#"x`, want: UnknownAction},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, correctInvalidActionName(testCase.input))
+	}
+}


### PR DESCRIPTION
Invalid action names received on webvitals endpoint are now all mapped to Unknown#unknown_method