### PR TITLE
Support header whitelist in graylog forwarder

### DIFF
--- a/doc/logjam-gelf-mapping.md
+++ b/doc/logjam-gelf-mapping.md
@@ -65,7 +65,7 @@ Example
   "_http_method": "GET",
   "_http_url": "/rest/jobs/postings/2196851",
   "_http_header_user_agent": "RestCake/0.10.6",
-  "_http_headers_not_extracted": "accept_encoding: deflate, gzip\naccept: application/json",
+  "_http_headers_not_extracted": "accept-encoding: deflate, gzip\naccept: application/json",
   "_logjam_message_size": 1192
 }
 ```

--- a/doc/logjam-gelf-mapping.md
+++ b/doc/logjam-gelf-mapping.md
@@ -25,20 +25,21 @@ level                 highest log level used in "lines" array, mapped to syslog 
 
 Additional fields:
 
-_app                  app-env -- first frame in logjam-device ZeroMQ message
-_total_time           total_time
-_code                 code
-_caller_id            caller_id
-_caller_action        caller_action
-_request_id           request_id
-_user_id              user_id
-_ip                   ip
-_process_id           process_id
-_datacenter           datacenter
-_http_method          request_info["method"]
-_http_url             request_info["url"]
-_http_header_*        all entries from request_info["headers"] as separate fields (normalize header name/key using lowercase letters and underscores)
-_logjam_message_size  the bytesize of the original logjam request message
+_app                         app-env -- first frame in logjam-device ZeroMQ message
+_total_time                  total_time
+_code                        code
+_caller_id                   caller_id
+_caller_action               caller_action
+_request_id                  request_id
+_user_id                     user_id
+_ip                          ip
+_process_id                  process_id
+_datacenter                  datacenter
+_http_method                 request_info["method"]
+_http_url                    request_info["url"]
+_http_header_*               whitelisted entries from request_info["headers"] as separate fields (normalize header name/key using lowercase letters and underscores)
+_http_headers_not_extracted  http headers not whitelisted in the form (header ": "" value)(header ": " value\n)*
+_logjam_message_size         the bytesize of the original logjam request message
 ```
 
 Example

--- a/doc/logjam-gelf-mapping.md
+++ b/doc/logjam-gelf-mapping.md
@@ -65,8 +65,7 @@ Example
   "_http_method": "GET",
   "_http_url": "/rest/jobs/postings/2196851",
   "_http_header_user_agent": "RestCake/0.10.6",
-  "_http_header_accept_encoding": "deflate, gzip",
-  "_http_header_accept": "application/json",
+  "_http_headers_not_extracted": "accept_encoding: deflate, gzip\naccept: application/json",
   "_logjam_message_size": 1192
 }
 ```

--- a/src/gelf-message.c
+++ b/src/gelf-message.c
@@ -44,6 +44,7 @@ const char* gelf_message_to_string(const gelf_message *msg)
 
 void gelf_message_destroy(gelf_message **msg)
 {
+    if (*msg == NULL) return;
     json_object *json = (json_object *) *msg;
     json_object_put(json);
     *msg = NULL;

--- a/src/graylog-forwarder-common.h
+++ b/src/graylog-forwarder-common.h
@@ -19,7 +19,7 @@ extern bool compress_gelf;
 #define DEFAULT_INTERFACE_PORT 9609
 #define DEFAULT_INTERFACE "tcp://0.0.0.0:9609"
 
-extern char* header_fields_file_name;
+extern char* headers_file_name;
 
 extern zlist_t *hosts;
 extern char *interface;

--- a/src/graylog-forwarder-common.h
+++ b/src/graylog-forwarder-common.h
@@ -19,6 +19,8 @@ extern bool compress_gelf;
 #define DEFAULT_INTERFACE_PORT 9609
 #define DEFAULT_INTERFACE "tcp://0.0.0.0:9609"
 
+extern char* header_fields_file_name;
+
 extern zlist_t *hosts;
 extern char *interface;
 extern zlist_t *subscriptions;

--- a/src/graylog-forwarder-controller.c
+++ b/src/graylog-forwarder-controller.c
@@ -77,6 +77,9 @@ int send_tick_commands(zloop_t *loop, int timer_id, void *arg)
     // send tick commands to actors to let them print out their stats
     zstr_send(state->writer, "tick");
     zstr_send(state->subscriber, "tick");
+    for (size_t i=0; i<num_parsers; i++) {
+        zstr_send(state->parsers[i], "tick");
+    }
 
     // get number of messages received by subscriber
     size_t messages_received = 0;

--- a/src/graylog-forwarder-controller.c
+++ b/src/graylog-forwarder-controller.c
@@ -54,12 +54,15 @@ bool controller_create_actors(controller_state_t *state, zlist_t* devices, int r
 static
 void controller_destroy_actors(controller_state_t *state)
 {
-    stream_config_updater_destroy(&state->stream_config_updater);
     zactor_destroy(&state->subscriber);
     zactor_destroy(&state->writer);
     for (size_t i=0; i<num_parsers; i++) {
         graylog_forwarder_parser_destroy(&state->parsers[i]);
     }
+    // The stream config updater must be shut after the parsers, otherwise the parsers
+    // block forever, since they need the config updater to process messages in order to
+    // get streamm info.
+    stream_config_updater_destroy(&state->stream_config_updater);
     watchdog_destroy(&state->watchdog);
 }
 

--- a/src/graylog-forwarder-controller.c
+++ b/src/graylog-forwarder-controller.c
@@ -59,9 +59,6 @@ void controller_destroy_actors(controller_state_t *state)
     for (size_t i=0; i<num_parsers; i++) {
         graylog_forwarder_parser_destroy(&state->parsers[i]);
     }
-    // The stream config updater must be shut after the parsers, otherwise the parsers
-    // block forever, since they need the config updater to process messages in order to
-    // get streamm info.
     stream_config_updater_destroy(&state->stream_config_updater);
     watchdog_destroy(&state->watchdog);
 }

--- a/src/graylog-forwarder-parser.c
+++ b/src/graylog-forwarder-parser.c
@@ -28,8 +28,10 @@ static void load_fields(parser_state_t *state) {
     FILE* file = fopen(header_fields_file_name, "r");
     if (!file)
         return;
+
     zhash_destroy(&state->header_fields);
     state->header_fields = zhash_new();
+
     char line[256] = {0};
     while (fgets(line, 256, file)) {
         int n = strlen(line);
@@ -153,7 +155,7 @@ parser_state_t* parser_state_new(zconfig_t* config, size_t id)
     state->scratch_buffer = zchunk_new(NULL, 4096);
     state->tokener = json_tokener_new();
     state->stream_info_cache = zhash_new();
-    state->header_fields = NULL;
+    state->header_fields = zhash_new();
     load_fields(state);
     return state;
 }

--- a/src/graylog-forwarder-parser.c
+++ b/src/graylog-forwarder-parser.c
@@ -21,6 +21,31 @@ typedef struct {
 } parser_state_t;
 
 
+static char *default_headers[] = {
+    "content-type",
+    "cookie",
+    "forwarded-user-agent",
+    "origin",
+    "referer",
+    "true-client-ip",
+    "user-agent",
+    "x-forwarded-for",
+    "x-original-forwarded-for",
+    "x-real-ip",
+    NULL
+};
+
+static zhash_t* default_headers_hash() {
+    zhash_t *headers = zhash_new();
+
+    for (char **p = &default_headers[0]; *p; p++) {
+        printf("[D] adding default header: %s\n", *p);
+        zhash_insert(headers, *p, (void*)1);
+    }
+
+    return headers;
+}
+
 static void load_headers(parser_state_t *state) {
     if (headers_file_name == NULL)
         return;
@@ -30,7 +55,7 @@ static void load_headers(parser_state_t *state) {
         return;
 
     zhash_destroy(&state->headers);
-    state->headers = zhash_new();
+    state->headers = default_headers_hash();
 
     char line[256] = {0};
     while (fgets(line, 256, file)) {
@@ -155,7 +180,7 @@ parser_state_t* parser_state_new(zconfig_t* config, size_t id)
     state->scratch_buffer = zchunk_new(NULL, 4096);
     state->tokener = json_tokener_new();
     state->stream_info_cache = zhash_new();
-    state->headers = zhash_new();
+    state->headers = default_headers_hash();
     load_headers(state);
     return state;
 }

--- a/src/graylog-forwarder-parser.c
+++ b/src/graylog-forwarder-parser.c
@@ -14,23 +14,23 @@ typedef struct {
     zchunk_t *scratch_buffer;               // scratch buffer for string operations
     json_tokener *tokener;                  // json tokener instance
     zhash_t *stream_info_cache;             // thread local stream info cache
-    zhash_t *header_fields;                 // whitelisted header fields
+    zhash_t *headers;                       // whitelisted HTTP headers
     size_t gelf_bytes;                      // size of uncompressed GELF messages
     size_t ticks;
     bool received_term_cmd;
 } parser_state_t;
 
 
-static void load_fields(parser_state_t *state) {
-    if (header_fields_file_name == NULL)
+static void load_headers(parser_state_t *state) {
+    if (headers_file_name == NULL)
         return;
 
-    FILE* file = fopen(header_fields_file_name, "r");
+    FILE* file = fopen(headers_file_name, "r");
     if (!file)
         return;
 
-    zhash_destroy(&state->header_fields);
-    state->header_fields = zhash_new();
+    zhash_destroy(&state->headers);
+    state->headers = zhash_new();
 
     char line[256] = {0};
     while (fgets(line, 256, file)) {
@@ -40,7 +40,7 @@ static void load_fields(parser_state_t *state) {
         }
         if (n > 0) {
             // printf("[D] adding whitelisted header: %s\n", line);
-            zhash_insert(state->header_fields, line, (void*)1);
+            zhash_insert(state->headers, line, (void*)1);
         }
     }
     fclose(file);
@@ -55,7 +55,7 @@ int process_message(zloop_t *loop, zsock_t *socket, void *arg)
     gelf_message *gelf_msg = NULL;
 
     if (logjam_msg && !zsys_interrupted) {
-        gelf_msg = logjam_message_to_gelf (logjam_msg, state->tokener, state->stream_info_cache, state->decompression_buffer, state->scratch_buffer, state->header_fields);
+        gelf_msg = logjam_message_to_gelf (logjam_msg, state->tokener, state->stream_info_cache, state->decompression_buffer, state->scratch_buffer, state->headers);
         // gelf message can be null for unknown streams or unparseable json
         if (gelf_msg == NULL) {
             goto cleanup;
@@ -155,8 +155,8 @@ parser_state_t* parser_state_new(zconfig_t* config, size_t id)
     state->scratch_buffer = zchunk_new(NULL, 4096);
     state->tokener = json_tokener_new();
     state->stream_info_cache = zhash_new();
-    state->header_fields = zhash_new();
-    load_fields(state);
+    state->headers = zhash_new();
+    load_headers(state);
     return state;
 }
 
@@ -169,7 +169,7 @@ void parser_state_destroy(parser_state_t **state_p)
     zsock_destroy(&state->push_socket);
     zchunk_destroy(&state->decompression_buffer);
     zchunk_destroy(&state->scratch_buffer);
-    zhash_destroy(&state->header_fields);
+    zhash_destroy(&state->headers);
     json_tokener_free(state->tokener);
     zhash_destroy(&state->stream_info_cache);
     free(state);
@@ -220,9 +220,9 @@ int timer_event(zloop_t *loop, int timer_id, void *args)
         state->stream_info_cache = zhash_new();
     }
 
-    // reload white listed fields file every 5 minutes
+    // reload white listed headers file every 5 minutes
     if (state->ticks % 300 == 0) {
-        load_fields(state);
+        load_headers(state);
     }
 
     return 0;

--- a/src/graylog-forwarder-parser.c
+++ b/src/graylog-forwarder-parser.c
@@ -53,7 +53,6 @@ int process_message(zloop_t *loop, zsock_t *socket, void *arg)
     gelf_message *gelf_msg = NULL;
 
     if (logjam_msg && !zsys_interrupted) {
-        goto cleanup;
         gelf_msg = logjam_message_to_gelf (logjam_msg, state->tokener, state->stream_info_cache, state->decompression_buffer, state->scratch_buffer, state->header_fields);
         // gelf message can be null for unknown streams or unparseable json
         if (gelf_msg == NULL) {

--- a/src/graylog-forwarder-subscriber.c
+++ b/src/graylog-forwarder-subscriber.c
@@ -196,8 +196,8 @@ int read_request_and_forward(zloop_t *loop, zsock_t *socket, void *callback_data
     zmsg_t *msg = zmsg_recv(socket);
 
     if (msg) {
-        if (debug)
-            my_zmsg_fprint(msg, "[D] ", stderr);
+        // if (debug)
+        //     my_zmsg_fprint(msg, "[D] ", stderr);
 
         state->message_count++;
         state->message_bytes += zmsg_content_size(msg);

--- a/src/logjam-graylog-forwarder.c
+++ b/src/logjam-graylog-forwarder.c
@@ -31,6 +31,7 @@ static char *logjam_stream_url = "http://localhost:3000/admin/streams";
 static const char* subscription_pattern = NULL;
 
 const char* default_datacenter = "unknown";
+char *header_fields_file_name = NULL;
 
 int metrics_port = 8083;
 char metrics_address[256] = {0};
@@ -55,6 +56,7 @@ static void print_usage(char * const *argv)
             "  -m, --metrics-port N       port to use for prometheus path /metrics\n"
             "  -M, --metrics-ip N         ip for binding metrics endpoint\n"
             "  -T, --trim-frequency N     malloc trim freqency in seconds, 0 means no trimming\n"
+            "  -H, --header-fields F      name of the whitelisted header fields file\n"
             "      --help                 display this message\n"
             "\nEnvironment: (parameters take precedence)\n"
             "  LOGJAM_DEVICES             specs of devices to connect to\n"
@@ -92,10 +94,11 @@ static void process_arguments(int argc, char * const *argv)
         { "metrics-port",   required_argument, 0, 'm' },
         { "metrics-ip",     required_argument, 0, 'M' },
         { "trim-frequency", required_argument, 0, 'T' },
+        { "header-fields",  required_argument, 0, 'H' },
         { 0,                0,                 0,  0  }
     };
 
-    while ((c = getopt_long(argc, argv, "vqc:np:zh:S:R:e:L:A:d:m:M:T:", long_options, &longindex)) != -1) {
+    while ((c = getopt_long(argc, argv, "vqc:np:zh:S:R:e:L:A:d:m:M:T:H:", long_options, &longindex)) != -1) {
         switch (c) {
         case 'v':
             if (verbose)
@@ -163,6 +166,10 @@ static void process_arguments(int argc, char * const *argv)
         case 'A':
             heartbeat_abort_after = atoi(optarg);
             break;
+        case 'H': {
+            header_fields_file_name = optarg;
+            break;
+        }
         case 0:
             print_usage(argv);
             exit(0);

--- a/src/logjam-graylog-forwarder.c
+++ b/src/logjam-graylog-forwarder.c
@@ -31,7 +31,7 @@ static char *logjam_stream_url = "http://localhost:3000/admin/streams";
 static const char* subscription_pattern = NULL;
 
 const char* default_datacenter = "unknown";
-char *header_fields_file_name = NULL;
+char *headers_file_name = NULL;
 
 int metrics_port = 8083;
 char metrics_address[256] = {0};
@@ -57,7 +57,7 @@ static void print_usage(char * const *argv)
             "  -m, --metrics-port N       port to use for prometheus path /metrics\n"
             "  -M, --metrics-ip N         ip for binding metrics endpoint\n"
             "  -T, --trim-frequency N     malloc trim freqency in seconds, 0 means no trimming\n"
-            "  -H, --header-fields F      name of the whitelisted header fields file\n"
+            "  -H, --headers H            name of the whitelisted HTTP headers file\n"
             "      --help                 display this message\n"
             "\nEnvironment: (parameters take precedence)\n"
             "  LOGJAM_DEVICES             specs of devices to connect to\n"
@@ -95,7 +95,7 @@ static void process_arguments(int argc, char * const *argv)
         { "metrics-port",   required_argument, 0, 'm' },
         { "metrics-ip",     required_argument, 0, 'M' },
         { "trim-frequency", required_argument, 0, 'T' },
-        { "header-fields",  required_argument, 0, 'H' },
+        { "headers",        required_argument, 0, 'H' },
         { 0,                0,                 0,  0  }
     };
 
@@ -168,7 +168,7 @@ static void process_arguments(int argc, char * const *argv)
             heartbeat_abort_after = atoi(optarg);
             break;
         case 'H': {
-            header_fields_file_name = optarg;
+            headers_file_name = optarg;
             break;
         }
         case 0:

--- a/src/logjam-graylog-forwarder.c
+++ b/src/logjam-graylog-forwarder.c
@@ -48,6 +48,7 @@ static void print_usage(char * const *argv)
             "  -n, --dryrun               don't send data to graylog\n"
             "  -p, --parsers N            use N threads for parsing log messages\n"
             "  -z, --compress             compress data sent to graylog\n"
+            "  -v, --verbose              verbose output (specify twice for debug mode)\n"
             "  -R, --rcv-hwm N            high watermark for input socket\n"
             "  -S, --snd-hwm N            high watermark for output socket\n"
             "  -L, --logjam-url U         url from where to retrieve stream config\n"
@@ -102,7 +103,7 @@ static void process_arguments(int argc, char * const *argv)
         switch (c) {
         case 'v':
             if (verbose)
-                debug= true;
+                debug = true;
             else
                 verbose = true;
             break;

--- a/src/logjam-message.c
+++ b/src/logjam-message.c
@@ -252,21 +252,19 @@ gelf_message* logjam_message_to_gelf(logjam_message *logjam_msg, json_tokener *t
                 // clear buffer data
                 zchunk_t *extra_headers = zchunk_new(0, 0);
                 json_object_object_foreach (obj, key, value) {
-                    char *lowkey = strdup(key);
-                    str_lower(lowkey);
-                    if (zhash_lookup(header_fields, lowkey)) {
-                        snprintf (header, 1024, "_http_header_%s", lowkey);
+                    str_lower(key);
+                    if (zhash_lookup(header_fields, key)) {
+                        snprintf (header, 1024, "_http_header_%s", key);
                         str_underscore(header + 13);
                         gelf_message_add_json_object (gelf_msg, header, value);
                     } else {
                         if (zchunk_size(extra_headers) > 0)
                             zchunk_extend(extra_headers, "\n", 1);
-                        zchunk_extend(extra_headers, lowkey, strlen(lowkey));
+                        zchunk_extend(extra_headers, key, strlen(key));
                         zchunk_extend(extra_headers, ": ", 2);
                         const char *val = json_object_get_string(value);
                         zchunk_extend(extra_headers, val, strlen(val));
                     }
-                    free(lowkey);
                 }
                 if (zchunk_size(extra_headers) > 0) {
                     zchunk_extend(extra_headers, "", 1);

--- a/src/logjam-message.c
+++ b/src/logjam-message.c
@@ -145,11 +145,14 @@ gelf_message* logjam_message_to_gelf(logjam_message *logjam_msg, json_tokener *t
     json_object *request = parse_json_data(json_data, json_data_len, tokener);
 
     if (!request) {
+        if (verbose)
+            printf("[D] could not parse JSON data: %*.s\n", (int)json_data_len, json_data);
         free(app_env);
         return NULL;
     }
 
-    // dump_json_object(stdout, "[D]", request);
+    if (debug)
+        dump_json_object(stdout, "[D]", request);
 
     if (json_object_object_get_ex (request, "host", &obj)) {
         host = json_object_get_string (obj);

--- a/src/logjam-message.c
+++ b/src/logjam-message.c
@@ -358,6 +358,9 @@ gelf_message* logjam_message_to_gelf(logjam_message *logjam_msg, json_tokener *t
 
 void logjam_message_destroy(logjam_message **msg)
 {
+    if (*msg == NULL)
+        return;
+
     for (int i = 0; i < 4; i++) {
         zframe_destroy (&(*msg)->frames[i]);
     }

--- a/src/logjam-message.h
+++ b/src/logjam-message.h
@@ -13,7 +13,7 @@ typedef struct {
 
 logjam_message* logjam_message_read(zsock_t *receiver);
 
-gelf_message* logjam_message_to_gelf(logjam_message *logjam_msg, json_tokener *tokener, zhash_t* stream_info_cache, zchunk_t *decompression_buffer, zchunk_t *scratch_buffer);
+gelf_message* logjam_message_to_gelf(logjam_message *logjam_msg, json_tokener *tokener, zhash_t* stream_info_cache, zchunk_t *decompression_buffer, zchunk_t *scratch_buffer, zhash_t *header_fields);
 
 void logjam_message_destroy(logjam_message **msg);
 

--- a/src/logjam-util.c
+++ b/src/logjam-util.c
@@ -466,12 +466,12 @@ int decompress_frame_snappy(zframe_t *body_frame, zchunk_t *buffer, char **body,
 
 size_t zchunk_ensure_size(zchunk_t *buffer, size_t desired_size)
 {
-    size_t current_size = zchunk_max_size(buffer);
+    size_t current_max_size = zchunk_max_size(buffer);
 
-    if (desired_size <= current_size)
-        return current_size;
+    if (desired_size <= current_max_size)
+        return current_max_size;
 
-    size_t next_size = 2 * current_size;
+    size_t next_size = current_max_size == 0 ? 1024 : 2 * current_max_size;
 
     while (next_size < max_buffer_size)
         next_size *= 2;


### PR DESCRIPTION
This change the logjam-graylog-forwarder to not create indexed fields in Graylog, in order to prevent an attacker to seriously affect the performance of the Graylog UI.

By default, http header in the logjam messages are now put into a single field **http_headers_not_extracted** using colons to separate header key from header value and newlines to separate individual headers. Header names will be transformed to lowercase to improve querying over all applications.

However, it is possible to provide a file of newline separated lower case http header names which will be turned into indexed field using the existing convention.